### PR TITLE
Tag team on time_to_merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ The following represents example metrics for time to merge, lines changed and ti
 ```
 Metric name: <prefix>.time_to_merge
 Metric value: 1624.0
-Tags: {project: "scribd/my_repository", "team:My_team"}
+Tags: {project: "scribd/my_repository", "team:my_team", "team:my_team2"}
 ```
 
-Note that team tags are only added if the author of the merge request is part of the organization the repository belongs to.
+Note that team tags are only added if the author of the merge request is part of the organization the repository belongs to. Multiple teams will be tagged if the user belongs to multiple teams in the organization.
 
 ```
 Metric name: <prefix>.lines_changed

--- a/report_github_metrics.rb
+++ b/report_github_metrics.rb
@@ -74,10 +74,10 @@ def collect_merged_data(github_client, repo)
   time_to_merge = pr_info["merged_at"] - pr_info["created_at"]
   diff_size = pr_info["additions"] + pr_info["deletions"]
   users_teams = find_teams(github_client, repo.split("/").first, pr_info.user.login)
-  tags = users_teams.map{|team| "team:#{team}"}
+  tags = users_teams.map{|team| "team:#{team}"} + ["project:#{repo}"]
   [
-    ["time_to_merge", time_to_merge, tags + ["project:#{repo}"]],
-    ["lines_changed", diff_size, tags + ["project:#{repo}"]]
+    ["time_to_merge", time_to_merge, tags],
+    ["lines_changed", diff_size, tags]
   ]
 end
 


### PR DESCRIPTION
Fetches the teams from the organization related to the repository if the user making the merge request is a part of that organization, and tags the time to merge metric with those teams.