### PR TITLE
TOOLS-3235: Setting up optional main branch tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ A prefix for all of the datadog metrics. If multiple projects in your organizati
 
 Internal configuration for the action. `job_metrics` should be passed for capturing job_duration and workflow durations, while `velocity` should be passed when used in a `Velocity Workflow` as seen below.
 
+### tagged-branches (Optional)
+
+An array of named branches to enable tagging of workflow metrics with `branch:{branch}` or `branch:other` depending on if the workflow is being run on a tagged branch or not. Only used if metrics-type is `job_metrics`. Example values: `'["main"]'`, `'["main", "staging", "production"]'`
+
 ## Environment Variables
 
 The following two secrets are required to be added to your GitHub settings for access to Datadog and GitHub during the workflow run.

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'An array of teams to tag the time to merge metric with'
     required: false
     default: '[]'
+  tagged-branches:
+    description: 'If provided enables tagging for specified branches. Metrics are tagged with branch:{branch} or branch:other'
+    required: false
+    default: '[]'
 runs:
   using: "composite"
   steps:
@@ -32,4 +36,4 @@ runs:
     - id: metric
       shell: bash
       run: |
-        ruby ${{ github.action_path }}/report_github_metrics.rb ${{github.repository}} ${{github.run_id}} ${{ inputs.datadog-metric-prefix }} '${{ inputs.teams }}'
+        ruby ${{ github.action_path }}/report_github_metrics.rb ${{github.repository}} ${{github.run_id}} ${{ inputs.datadog-metric-prefix }} '${{ inputs.teams }}' '${{ inputs.tagged-branches }}'


### PR DESCRIPTION
Adds the optional field for specifying a branch name to tag for workflow metrics.