### PR TITLE
Cap versions of octokit to 4.25.1 and dogapi to 1.45.0 and remove silent flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,8 +27,8 @@ runs:
     - name: Install required libraries for gems
       shell: bash
       run: |
-        gem install octokit --silent
-        gem install dogapi --silent
+        gem install octokit -v 4.25.1
+        gem install dogapi -v 1.45.0
     - name: Export extra data
       shell: bash
       run: |


### PR DESCRIPTION
Newer version of octokit will not work with Ruby 2.6

<img width="1093" alt="Screen Shot 2022-07-12 at 2 27 54 PM" src="https://user-images.githubusercontent.com/3541764/178569481-4f7e417c-bcac-4075-b610-13f235bd4102.png">


