### PR TITLE
Bug fix: report workflow status as cancelled if any of the jobs is cancelled

### DIFF
--- a/report_github_metrics.rb
+++ b/report_github_metrics.rb
@@ -21,7 +21,13 @@ end
 def collect_workflow_metrics(jobs, tags)
   start = jobs.min_by{|job| job["started_at"]}["started_at"]
   finish = jobs.max_by{|job| job["completed_at"]}["completed_at"]
-  status = jobs.all?{|job| ["success", "skipped"].include? job["conclusion"]} ? "success" : "failure"
+  status = if jobs.any?{|job| job["conclusion"] == "cancelled"}
+             "cancelled"
+           elsif jobs.all?{|job| ["success", "skipped"].include? job["conclusion"]}
+             "success"
+           else
+             "failure"
+           end
   [[
     "workflow_duration",
     finish - start,


### PR DESCRIPTION
If any of the workflow jobs is cancelled, the whole workflow status should be reported as `cancelled` as well. Previously it would be reported as `failure`.

Tested by pointing an existing workflow to this version of the action and then cancelled the workflow and confirmed the `cancelled` status is now reported for that workflow.