### PR TITLE
Adds option to override the Datadog API url

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ An array of named branches to enable tagging of workflow and job metrics with `b
 
 An array of custom tags to attach to any metrics sent to datadog. Example values: `'["tag:value"]'`, `'["tag1:value1", "tag2:value2"]'`
 
+### api-url (Optional)
+
+The datadog api url. Defaults to `https://api.datadoghq.com`.  Can be used to override for datadog regional endpoints or a proxy.
+
 ## Environment Variables
 
 The following two secrets are required to be added to your GitHub settings for access to Datadog and GitHub during the workflow run.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'A list of tags to attach to the metrics. In the format of "[TAG1:VALUE1,TAG2:VALUE2,..]".'
     required: false
     default: '[]'
+  api-url:
+    description: 'The datadog regional api url. Defaults to https://api.datadoghq.com'
+    required: false
+    default: 'https://api.datadoghq.com'
 
 runs:
   using: "composite"
@@ -41,4 +45,4 @@ runs:
     - id: metric
       shell: bash
       run: |
-        ruby ${{ github.action_path }}/report_github_metrics.rb ${{github.repository}} ${{github.run_id}} ${{ inputs.datadog-metric-prefix }} '${{ inputs.teams }}' '${{ inputs.tagged-branches }}' '${{ inputs.custom-tags }}'
+        ruby ${{ github.action_path }}/report_github_metrics.rb ${{github.repository}} ${{github.run_id}} ${{ inputs.datadog-metric-prefix }} '${{ inputs.teams }}' '${{ inputs.tagged-branches }}' '${{ inputs.custom-tags }}' ${{ inputs.api-url }}

--- a/report_github_metrics.rb
+++ b/report_github_metrics.rb
@@ -109,6 +109,7 @@ metric_prefix = ARGV[2].strip
 teams = parse_array_input(ARGV[3])
 metric_prefix += "." unless metric_prefix.end_with?(".")
 datadog_client = Dogapi::Client.new(ENV['DATADOG_API_KEY'])
+datadog_client.datadog_host = ARGV[6].strip
 github_client = Octokit::Client.new(:access_token => ENV['OCTOKIT_TOKEN'])
 
 metrics = nil


### PR DESCRIPTION
Optionally override the datadog API url.

Specifically this allows us to use this action with a https://api.datadoghq.eu instance of datadog, other users may also be using a proxy.

Should be backwards compatible, non-breaking, as defaults to the ruby client's default url https://api.datadoghq.com