### PR TITLE
Fix bug with reporting duration of rerun workflows

### DIFF
--- a/report_github_metrics.rb
+++ b/report_github_metrics.rb
@@ -4,9 +4,9 @@ require 'dogapi'
 require 'date'
 require 'json'
 
-def collect_metrics(jobs, tags)
+def collect_metrics(workflow, jobs, tags)
   jobs.map{|job| collect_job_metrics(job, tags)}.compact + \
-  collect_workflow_metrics(jobs, tags)
+  collect_workflow_metrics(workflow, jobs, tags)
 end
 
 def collect_job_metrics(job, tags)
@@ -18,8 +18,8 @@ def collect_job_metrics(job, tags)
   ]
 end
 
-def collect_workflow_metrics(jobs, tags)
-  start = jobs.min_by{|job| job["started_at"]}["started_at"]
+def collect_workflow_metrics(workflow, jobs, tags)
+  start = workflow["run_started_at"]
   finish = jobs.max_by{|job| job["completed_at"]}["completed_at"]
   status = if jobs.any?{|job| job["conclusion"] == "cancelled"}
              "cancelled"
@@ -93,7 +93,7 @@ def collect_duration_data(github_client, repo, run)
   if TAGGED_BRANCHES != []
     tags += ["branch:#{TAGGED_BRANCHES.include?(branch) ? branch : "other" }"]
   end
-  collect_metrics(jobs, tags)
+  collect_metrics(workflow, jobs, tags)
 end
 
 def parse_array_input(arg)


### PR DESCRIPTION
When a workflow is rerun using `Re-run failed jobs` option in Github UI, the jobs which were successful in the previous run will report the same start_time as before under the new workflow run metrics. Since we use the earliest and latest job durations to calculate workflow duration, above issue will lead to incorrectly high duration for the rerun workflow. The correct approach would be to use the `run_started_at` value of the corresponding workflow run to calculate the duration.

<img width="398" alt="Screen Shot 2023-01-09 at 3 52 09 PM" src="https://user-images.githubusercontent.com/3541764/211406283-d8297f6b-d594-4322-8842-903807a37826.png">
