### PR TITLE
Add faraday-retry dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ ruby "3.2.2"
 
 gem 'octokit', '~> 7.1'
 gem 'dogapi', '~> 1.45'
+gem 'faraday-retry', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
     multi_json (1.15.0)
     octokit (7.1.0)
       faraday (>= 1, < 3)
@@ -27,6 +29,7 @@ PLATFORMS
 
 DEPENDENCIES
   dogapi (~> 1.45)
+  faraday-retry (~> 2.2)
   octokit (~> 7.1)
 
 RUBY VERSION


### PR DESCRIPTION
Add [faraday-retry](https://github.com/lostisland/faraday-retry) dependency to get automated retries for failures and also remove the following warning when using the action:
> To use retry middleware with Faraday v2.0+, install `faraday-retry` gem