### PR TITLE
Add 'retry' tag in workflow metrics

### DIFF
--- a/report_github_metrics.rb
+++ b/report_github_metrics.rb
@@ -28,10 +28,11 @@ def collect_workflow_metrics(workflow_run, jobs, tags)
            else
              "failure"
            end
+  is_retry = workflow_run["run_attempt"] > 1
   [[
     "workflow_duration",
     finish - start,
-    tags + ["status:#{status}"]
+    tags + ["status:#{status}","retry:#{is_retry}"]
   ]]
 end
 


### PR DESCRIPTION
When a workflow is retried via Github UI (either in full or just the failed jobs), this action will report all workflow & job metrics from the new run as if it is a completely new/independent run. By adding a `retry` tag in the workflow metric we can keep track of retries and potential duplication across metrics captured by this action.